### PR TITLE
Add projectType configuration field to options.yaml

### DIFF
--- a/finish/src/main/config/options.yaml
+++ b/finish/src/main/config/options.yaml
@@ -1,3 +1,4 @@
+projectType: provider
 provider: CICS
 programInterface: CHANNEL
 language: COBOL

--- a/start/src/main/config/options.yaml
+++ b/start/src/main/config/options.yaml
@@ -1,3 +1,4 @@
+projectType: provider
 provider: CICS
 programInterface: CHANNEL
 language: COBOL


### PR DESCRIPTION
# Summary

Add `projectType` configuration field to options.yaml files. This change introduces a new `projectType: provider` field at the beginning of the configuration files in both the start and finish directories, explicitly defining the project type for the CICS provider configuration.

# Files Changed

📄 `finish/src/main/config/options.yaml`

Added `projectType: provider` as the first configuration field to explicitly specify the project type in the finished example configuration.

📄 `start/src/main/config/options.yaml`

Added `projectType: provider` as the first configuration field to explicitly specify the project type in the starter example configuration.